### PR TITLE
Add get_rhyme_categories method to Poem

### DIFF
--- a/ds/poem.py
+++ b/ds/poem.py
@@ -1,4 +1,8 @@
 import regex as re
+from itertools import chain
+
+from .helpers import window
+from .pronunciation import get_rhyme
 
 
 class Poem(dict):
@@ -12,3 +16,29 @@ class Poem(dict):
                 # add $ to force end of line
                 for last_char in re.findall(f'([^{patt}])[{patt}]+{end}', line)
                 ]
+
+    def get_rhyme_categories(self, prons):
+        # retrieve characters that are in rhyme position
+        rhymes = self.get_rhymes()
+
+        # obtain their GY rhyme: many will have several possibilities
+        # e.g. 長 => 陽 / 漾 / 養
+        rhyme_sets = list(map(frozenset, map(lambda rh: get_rhyme(rh, prons),
+                                             rhymes)))
+
+        # disambiguate by looking at which rhymes would actually rhyme
+        # e.g. if the line before/after contains 章 (陽 as the only possible
+        # rhyme), then 長 must be read as the 陽 rhyme too.
+        gy_rhymes = list()
+        window_size = 5  # look 2 lines before and after
+
+        for w in window(rhyme_sets, window_size, pad=True):
+            candidate = w.pop(window_size//2)
+            surrounding = set(chain.from_iterable(w))
+            if len(candidate) > 1 and len(candidate & surrounding) > 0:
+                # reduce to the set of possibilities (usu. down to 1)
+                gy_rhymes.append(frozenset(candidate & surrounding))
+            else:
+                gy_rhymes.append(candidate)
+
+        return [''.join(sorted(gy)) for gy in gy_rhymes]

--- a/ds/pronunciation.py
+++ b/ds/pronunciation.py
@@ -161,3 +161,7 @@ def get_final(pron):
              extract_final_baxter(subpron['GY Baxter']))
             for subpron in pron
             ] or [extract_final_schuessler(pron[0]['MC/QY'])]
+
+
+def get_rhyme(c, prons):
+    return sorted(set(p['GY Rhyme'] for p in prons[c] if p['GY Rhyme']))

--- a/test/test_poem.py
+++ b/test/test_poem.py
@@ -11,6 +11,12 @@ class TestPoem(unittest.TestCase):
             "烽火連三月，家書抵萬金。",
             "白頭搔更短，渾欲不勝簪。"
         ]
+        self.prons = {
+            '深': [{'GY Rhyme': '侵'}, {'GY Rhyme': '沁'}],
+            '心': [{'GY Rhyme': '侵'}],
+            '金': [{'GY Rhyme': '侵'}],
+            '簪': [{'GY Rhyme': '侵'}, {'GY Rhyme': '覃'}],
+        }
 
     def test_poem(self):
         p = poem.Poem(paragraphs=self.poem, author='杜甫', title='春望')
@@ -21,3 +27,8 @@ class TestPoem(unittest.TestCase):
     def test_get_rhymes(self):
         p = poem.Poem(paragraphs=self.poem)
         self.assertEquals(['深', '心', '金', '簪'], p.get_rhymes())
+
+    def test_get_rhyme_categories(self):
+        p = poem.Poem(paragraphs=self.poem)
+        self.assertEquals(['侵', '侵', '侵', '侵'],
+                          p.get_rhyme_categories(self.prons))


### PR DESCRIPTION
As opposed to get_rhymes, which returns characters of a poem which are involved
in a rhyming set, get_rhyme_categories will return the corresponding Guangyun
rhyme categories (e.g. the rhyme character 紅 has the rhyme category 東).

Since characters can have several pronunciations (and therefore multiple
categories), this tries to resolve ambiguities by looking at the lines around;
this often results in producing a single category per rhyme.