### PR TITLE
Add find_rhyme_pairs method to Poem

### DIFF
--- a/ds/helpers.py
+++ b/ds/helpers.py
@@ -8,7 +8,7 @@ def filter_constraint(constraint_dict, it):
 
 
 def window(lst, n, pad=False):
-    if pad:
+    if pad and len(lst) > 0:
         assert n % 2 == 1 and n > 1
         padding = [type(lst[0])()] * (n // 2)
         lst = padding + lst + padding

--- a/ds/poem.py
+++ b/ds/poem.py
@@ -1,7 +1,7 @@
 import regex as re
-from itertools import chain
+from itertools import chain, product
 
-from .helpers import window
+from .helpers import window, window_combinations
 from .pronunciation import get_rhyme
 
 
@@ -42,3 +42,10 @@ class Poem(dict):
                 gy_rhymes.append(candidate)
 
         return [''.join(sorted(gy)) for gy in gy_rhymes]
+
+    def find_rhyme_pairs(self, prons, pair):
+        gy_rhymes = self.get_rhyme_categories(prons)
+        rhyme_pairs = set(map(tuple, map(sorted,
+                                         window_combinations(gy_rhymes, 2))))
+        searched_pairs = set(map(tuple, map(sorted, product(*pair))))
+        return set(searched_pairs) & set(rhyme_pairs)

--- a/test/test_poem.py
+++ b/test/test_poem.py
@@ -32,3 +32,19 @@ class TestPoem(unittest.TestCase):
         p = poem.Poem(paragraphs=self.poem)
         self.assertEquals(['侵', '侵', '侵', '侵'],
                           p.get_rhyme_categories(self.prons))
+
+    def test_find_rhyme_pairs(self):
+        p = poem.Poem(paragraphs=['風雅不墜地，五言始君先。',  # 先
+                                  '希微嘉會章，杳冥河梁篇。',  # 仙
+                                  '理蔓語無枝，言一意則千。',  # 先
+                                  '往來更後人，澆蕩醨前源。',  # 元
+                                  ])
+        prons = {
+            '先': [{'GY Rhyme': '先'}],
+            '篇': [{'GY Rhyme': '仙'}],
+            '千': [{'GY Rhyme': '先'}],
+            '源': [{'GY Rhyme': '元'}],
+        }
+
+        self.assertEquals({('元', '先'), },
+                          p.find_rhyme_pairs(prons, ('仙先文', '元')))


### PR DESCRIPTION
The goal of this method is to find whether a given poem exhibits a particular
rhyme pair; the main use case is to try it with surprising pairs (things that
supposedly should not rhyme, but do). The return value is a set of all pairs
found, so that an empty set means the poem does not exhibit the searched
pattern.