### PR TITLE
Rework plot function to handle communities

### DIFF
--- a/ds/poem.py
+++ b/ds/poem.py
@@ -8,7 +8,7 @@ from .pronunciation import get_rhyme
 class Poem(dict):
     def get_rhymes(self, lines=None, split=False):
         # this needs improvement: not every character will be a rhyme
-        patt = r'，。\]'
+        patt = r'，。）\]'
         end = '' if split else '$'
 
         return [last_char

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -76,7 +76,7 @@ class TestCommunities(unittest.TestCase):
     def test_keep_only_communities(self):
         nx = graph.py2nx(self.nodes, self.edges)
         comms = graph.get_communities(nx)
-        graph.keep_only_communities(nx, comms)
+        nx = graph.keep_only_communities(nx, comms)
 
         self.assertNotIn(('a', 'e'), nx.edges)
         for edge in set(self.edges.keys()) - {('a', 'e')}:


### PR DESCRIPTION
The graph.plot function now allows passing a list of communities; if so, each
community gets a different colour in the graph and the graph can use the
communities to rearrange the layout, so as to show communities clearly
separated from each other.