### PR TITLE
Add align_communities function

### DIFF
--- a/ds/community.py
+++ b/ds/community.py
@@ -1,0 +1,68 @@
+from collections import Counter
+from operator import itemgetter
+
+from .helpers import get_average_precision
+from .pronunciation import get_rhyme
+
+
+def get_community_rhyme_categories(community, prons):
+    rhyme_cnt = Counter(rhyme
+                        for char in community
+                        for rhyme in get_rhyme(char, prons))
+    return Counter(dict(rhyme_cnt.most_common(8)))
+
+
+def align_communities(comms_a, comms_b):
+    def top_rhymes(community, n):
+        return list(map(itemgetter(0), community.most_common(n)))
+
+    def basic_align(comms_1, comms_2):
+        res = dict()
+        for i, comm_1 in enumerate(comms_1):
+            if len(comm_1) == 0:
+                continue
+            max_sc = 0
+            max_j = -1
+            for j, comm_2 in enumerate(comms_2):
+                if len(comm_2) == 0:
+                    continue
+                mc = 3
+                sc = get_average_precision(top_rhymes(comm_2, mc),
+                                           top_rhymes(comm_1, mc))
+                if sc > max_sc:
+                    max_sc = sc
+                    max_j = j
+            if max_j != -1:
+                res[i] = max_j
+        return res
+
+    def get_symmetric_score(comm_a, comm_b):
+        mc = 8
+        a_rhymes = top_rhymes(comm_a, mc)
+        b_rhymes = top_rhymes(comm_b, mc)
+        return max(get_average_precision(a_rhymes, b_rhymes),
+                   get_average_precision(b_rhymes, a_rhymes))
+
+    def overlap(comm_a, comm_b):
+        return len(set(comm_a) & set(comm_b))
+
+    # try aligning in both directions
+    ab_align = basic_align(comms_a, comms_b)
+    ba_align = basic_align(comms_b, comms_a)
+    realign = dict()
+    for k, v in ab_align.items():
+        # where they don't agree, pick the highest one
+        if ba_align[v] != k:
+            ab = get_symmetric_score(comms_a[k], comms_b[v])
+            ba = get_symmetric_score(comms_a[ba_align[v]], comms_b[v])
+            overlap_ab = overlap(comms_a[k], comms_b[v])
+            overlap_ba = overlap(comms_a[ba_align[v]], comms_b[v])
+
+            if ba > ab or (ba == ab and overlap_ba > overlap_ab):
+                k = ba_align[v]
+        realign[k] = v
+
+    ret = list()
+    for k, v in realign.items():
+        ret.append((comms_a[k], comms_b[v]))
+    return ret

--- a/test/test_community.py
+++ b/test/test_community.py
@@ -1,0 +1,63 @@
+import unittest
+from collections import Counter
+
+from ds import community
+
+
+class TestGetCommunityRhymeCategories(unittest.TestCase):
+    def test_get_community_rhyme_categories(self):
+        prons = {
+            '深': [{'GY Rhyme': '侵'}, {'GY Rhyme': '沁'}],
+            '心': [{'GY Rhyme': '侵'}],
+            '金': [{'GY Rhyme': '侵'}],
+            '簪': [{'GY Rhyme': '侵'}, {'GY Rhyme': '覃'}],
+
+            '沒': [{'GY Rhyme': '沒'}],
+            '發': [{'GY Rhyme': '月'}],
+            '室': [{'GY Rhyme': '質'}],
+            '骨': [{'GY Rhyme': '沒'}],
+            '佛': [{'GY Rhyme': '物'}],
+            '別': [{'GY Rhyme': '薛'}, {'GY Rhyme': '薛'}],
+            '曰': [{'GY Rhyme': '月'}],
+        }
+        communities = [{'深', '心', '金', '簪'},
+                       {'沒', '發', '室', '骨', '佛', '別', '曰'}]
+
+        self.assertEquals(
+            Counter({'侵': 4, '沁': 1, '覃': 1}),
+            community.get_community_rhyme_categories(communities[0], prons))
+        self.assertEquals(
+            Counter({'月': 2, '沒': 2, '質': 1, '薛': 1, '物': 1}),
+            community.get_community_rhyme_categories(communities[1], prons))
+
+
+class TestAlignCommunities(unittest.TestCase):
+    def test_align_communities(self):
+        corpus_a_comms = [Counter({'侵': 4, '沁': 1, '覃': 1}),
+                          Counter({'沒': 2, '質': 1, '薛': 1}),
+                          Counter(),  # empty communities are ignored
+                          ]
+
+        corpus_b_comms = [Counter({'侵': 4}),
+                          Counter({'月': 2, '沒': 2, '質': 1, '薛': 1, '物': 1}),
+                          Counter()]
+
+        self.assertEquals(
+            [(Counter({'侵': 4, '沁': 1, '覃': 1}),
+              Counter({'侵': 4})),
+
+             (Counter({'沒': 2, '質': 1, '薛': 1}),
+              Counter({'月': 2, '沒': 2, '質': 1, '薛': 1, '物': 1}))],
+            community.align_communities(corpus_a_comms, corpus_b_comms))
+
+    def test_resolution_of_ambiguities(self):
+        corpus_a_comms = [Counter({'侵': 4}),
+                          Counter({'侵': 4, '沁': 1, '覃': 1}),
+                          ]
+
+        corpus_b_comms = [Counter({'侵': 4, '沁': 1})]
+
+        self.assertEquals(
+            [(Counter({'侵': 4, '沁': 1, '覃': 1}),
+              Counter({'侵': 4, '沁': 1}))],
+            community.align_communities(corpus_a_comms, corpus_b_comms))


### PR DESCRIPTION
When presented with two corpora (or divisions of a single corpora) and given
their communities of rhymes, it is interesting to align the communities so that
we can later compare e.g. the composition of the 歌/戈 community of corpus A
with that of corpus B, and see if there are merges on one side or the other.