### PR TITLE
Add get_top_missing function

### DIFF
--- a/ds/community.py
+++ b/ds/community.py
@@ -66,3 +66,11 @@ def align_communities(comms_a, comms_b):
     for k, v in realign.items():
         ret.append((comms_a[k], comms_b[v]))
     return ret
+
+
+def get_top_missing(comm_a, comm_b):
+    chars_in_common = set(comm_a) & set(comm_b)
+    sorted_chars_a = list(map(itemgetter(0), comm_a.most_common()))
+    useful_range = max(map(sorted_chars_a.index, chars_in_common))
+    useful_chars = set(sorted_chars_a[:useful_range])
+    return useful_chars - set(comm_b)

--- a/test/test_community.py
+++ b/test/test_community.py
@@ -61,3 +61,19 @@ class TestAlignCommunities(unittest.TestCase):
             [(Counter({'侵': 4, '沁': 1, '覃': 1}),
               Counter({'侵': 4, '沁': 1}))],
             community.align_communities(corpus_a_comms, corpus_b_comms))
+
+
+class TestGetTopMissing(unittest.TestCase):
+    def test_get_top_missing(self):
+        comm_a = Counter({'庚': 72, '青': 69, '清': 52, '耕': 40, '映': 12,
+                          '徑': 9, '勁': 7, '迥': 6})
+        comm_b = Counter({'青': 12, '徑': 3, '迥': 2, '清': 2, '靜': 1, '支': 1,
+                          '至': 1})
+        # the last char of A that is in B is 迥, so we consider the entire A
+        # of which several characters are missing in B
+        self.assertEquals({'勁', '映', '耕', '庚'},
+                          community.get_top_missing(comm_a, comm_b))
+        # the last char of B that is in A is 清, so we consider up the first 4
+        # of which no character is missing in A
+        self.assertEquals(set(),
+                          community.get_top_missing(comm_b, comm_a))


### PR DESCRIPTION
This highlights rhyme categories that are present in the community of a corpus
A but that are missing in the equivalent community of a corpus B. This is done
in a slightly more complex way than simply doing a set difference (because
noise in the data would return too many to be useful), instead restricting the
A community to the most frequent characters so that the restricted community
contains all the characters of A that are also in B (a "useful" overlap). In
practice, this gives good results.