### PR TITLE
Add filter_by_time_range function

### DIFF
--- a/ds/authors.py
+++ b/ds/authors.py
@@ -72,6 +72,9 @@ def load_authors(collection):
     with open(AUTHOR_CACHE) as f:
         reader = csv.DictReader(f)
         for line in reader:
+            line['c_index_year'] = (int(line['c_index_year'])
+                                    if line['c_index_year']
+                                    else None)
             if line['dynasty'] == DYNASTY.get(collection):
                 ret[line['c_name_chn']].append(line)
 
@@ -94,3 +97,8 @@ def filter_by_area(area, authors):
         return filter_by_area({area}, authors)
 
     return filter_constraint({'province': area.__contains__}, authors)
+
+
+def filter_by_time_range(time_range, authors):
+    return filter_constraint({'c_index_year': time_range.__contains__},
+                             authors)

--- a/test/test_authors.py
+++ b/test/test_authors.py
@@ -68,3 +68,18 @@ class TestAuthors(unittest.TestCase):
         self.assertEquals(1, len(shaanxi))
         self.assertEquals('韓愈', shaanxi[0]['c_name_chn'])
         self.assertEquals('歐陽詹', fujian[0]['c_name_chn'])
+
+    def test_filter_by_time_range(self):
+        auths = authors.load_authors('qts')
+        self.assertEquals(802, auths['歐陽詹'][0]['c_index_year'])
+        self.assertEquals(825, auths['韓愈'][0]['c_index_year'])
+
+        auths = [auths['歐陽詹'][0], auths['韓愈'][0]]
+
+        early = authors.filter_by_time_range(range(618, 810), auths)
+        late = authors.filter_by_time_range(range(810, 907), auths)
+
+        self.assertEquals(1, len(early))
+        self.assertEquals(1, len(late))
+        self.assertEquals('韓愈', late[0]['c_name_chn'])
+        self.assertEquals('歐陽詹', early[0]['c_name_chn'])


### PR DESCRIPTION
This allows filtering author by period, either pre-defined (e.g. Tang, Song,
Southern Song, High Tang etc) or by a specific range (e.g. 800-830). This can
be useful to track changes in style or rhyming practice etc through time.