### PR TITLE
Add filter_by_period function for CBDB

### DIFF
--- a/test/test_cbdb.py
+++ b/test/test_cbdb.py
@@ -29,3 +29,19 @@ class TestCbdb(unittest.TestCase):
         ret = cbdb.filter_by_job(rows, job='poet')
         self.assertEqual(1, len(ret))
         self.assertEqual(757, ret[0]['c_birthyear'])
+
+
+class TestFilterByPeriod(unittest.TestCase):
+    def test_filter_by_period(self):
+        allowed_span = range(cbdb.DYNASTIES['唐'][0] - cbdb.LIFE_SPAN,
+                             cbdb.DYNASTIES['唐'][-1] + cbdb.LIFE_SPAN)
+
+        persons = cbdb.get_person('劉濟')  # no dynasty restriction
+        self.assertFalse(all(p['c_index_year'] is None or
+                             p['c_index_year'] in allowed_span
+                             for p in persons))
+
+        persons = cbdb.get_person('劉濟', dyn='唐')
+        self.assertTrue(all(p['c_index_year'] is None or
+                            p['c_index_year'] in allowed_span
+                            for p in persons))


### PR DESCRIPTION
This allows restricting the people returned by get_person to a specific time
range; if birth and death years are known, these are used; otherwise, they are
estimated from the other by subtracting / adding 80 years (i.e. if we only know
a person to be born in 880AD, we estimate their death in 960AD). If none of
these is known, the Index year is used.