### PR TITLE
Return communities as a list

### DIFF
--- a/ds/graph.py
+++ b/ds/graph.py
@@ -74,9 +74,9 @@ def get_communities(nx_graph):
     i_graph = nx2igraph(nx_graph)
     communities = i_graph.community_infomap(edge_weights='weight',
                                             vertex_weights='weight')
-    ret = {frozenset(map(itemgetter('label'),
+    ret = [frozenset(map(itemgetter('label'),
                          map(i_graph.vs.__getitem__, community)))
-           for community in communities}
+           for community in communities]
     print('Communities computed')
     return ret
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -69,9 +69,9 @@ class TestCommunities(unittest.TestCase):
     def test_get_communities(self):
         nx = graph.py2nx(self.nodes, self.edges)
         comms = graph.get_communities(nx)
-        self.assertEquals({frozenset({'a', 'wa', 'ia'}),
-                           frozenset({'e', 'ie'})},
-                          comms)
+        self.assertEquals(sorted([frozenset({'a', 'wa', 'ia'}),
+                                  frozenset({'e', 'ie'})]),
+                          sorted(comms))
 
     def test_keep_only_communities(self):
         nx = graph.py2nx(self.nodes, self.edges)


### PR DESCRIPTION
This guarantees greater stability between runs.