### PR TITLE
Remove rhyme_group_fun parameter

### DIFF
--- a/ds/graph.py
+++ b/ds/graph.py
@@ -27,12 +27,13 @@ def nx2igraph(nx_graph):
     return ret
 
 
-def build_single_poem_graph(poem, rhyme_group_fun):
+def build_single_poem_graph(poem):
     nodes = Counter()
     edges = Counter()
-    rhymes = rhyme_group_fun(poem)
+    rhymes = [poem.get_rhymes()]
+    rhyme_categories = rhymes
     rhyme_groups = map(lambda x: list(map(lambda y: Node(*y), zip(*x))),
-                       zip(rhymes, rhymes))
+                       zip(rhymes, rhyme_categories))
     for rhyme_group in rhyme_groups:
         for c in rhyme_group:
             nodes[c] += 1
@@ -42,11 +43,11 @@ def build_single_poem_graph(poem, rhyme_group_fun):
     return nodes, edges
 
 
-def build_python_graph(poems, rhyme_group_fun):
+def build_python_graph(poems):
     nodes = Counter()
     edges = Counter()
     for poem in tqdm(poems):
-        poem_nodes, poem_edges = build_single_poem_graph(poem, rhyme_group_fun)
+        poem_nodes, poem_edges = build_single_poem_graph(poem)
         for n, w in poem_nodes.items():
             nodes[n] += w
         for e, w in poem_edges.items():
@@ -69,8 +70,8 @@ def py2nx(nodes, edges):
 # public functions
 
 
-def build_graph(poems, rhyme_group_fun=lambda poem: [poem.get_rhymes()]):
-    nodes, edges = build_python_graph(poems, rhyme_group_fun)
+def build_graph(poems):
+    nodes, edges = build_python_graph(poems)
     return py2nx(nodes, edges)
 
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -13,13 +13,8 @@ class TestGraph(unittest.TestCase):
                      '白頭搔更短，渾欲不勝簪。']
         self.poem = Poem({'paragraphs': self.poem})
 
-    @staticmethod
-    def grouping_fun(p):
-        return [Poem.get_rhymes(p)]
-
     def test_build_single_poem_graph(self):
-        nodes, edges = graph.build_single_poem_graph(self.poem,
-                                                     self.grouping_fun)
+        nodes, edges = graph.build_single_poem_graph(self.poem)
 
         N = {k: graph.Node(k, k) for k in '深心金簪'}
         self.assertEquals(Counter(map(N.get, '深心金簪')), nodes)
@@ -32,17 +27,14 @@ class TestGraph(unittest.TestCase):
                           edges)
 
     def test_build_python_graph(self):
-        p_nodes, p_edges = graph.build_single_poem_graph(self.poem,
-                                                         self.grouping_fun)
+        p_nodes, p_edges = graph.build_single_poem_graph(self.poem)
         # we build a corpus of twice the same poem
-        nodes, edges = graph.build_python_graph([self.poem, self.poem],
-                                                self.grouping_fun)
+        nodes, edges = graph.build_python_graph([self.poem, self.poem])
         self.assertEquals(p_nodes + p_nodes, nodes)
         self.assertEquals(p_edges + p_edges, edges)
 
     def test_py2nx(self):
-        nodes, edges = graph.build_single_poem_graph(self.poem,
-                                                     self.grouping_fun)
+        nodes, edges = graph.build_single_poem_graph(self.poem)
         gph = graph.py2nx(nodes, edges)
         for node, data in gph.nodes(data=True):
             self.assertEquals(nodes[node], data['weight'])


### PR DESCRIPTION
This parameter was an early optimisation, to allow to test different rhyme
grouping strategies. This parameter then had to be passed through the entire
call stack, despite - in practice - always having the same value. Its removal
makes things much cleaner and paves the way for internal handling of both
rhyme grouping and rime attribution.